### PR TITLE
update Node version to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ outputs:
   permitted:
     description: 'Whether a user is part of the team or not'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   color: 'red'


### PR DESCRIPTION
The following warning is shown when using the action:

`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: TheModdingInquisition/actions-team-membership`